### PR TITLE
Allow ignore.method to filter without path elements.

### DIFF
--- a/lib/Patronus.js
+++ b/lib/Patronus.js
@@ -252,15 +252,17 @@
     // pass in a route to get back a function that checks if the route matches
     internals.ignoredRoute = function(route) {
         return function(e) {
-            if(e.method) {
-                if(e.method !== route.method) {
-                    return false;
-                }
+            if((e.pathContains || e.path) && e.method && e.method !== route.method) {
+                return false;
             }
             if(e.pathContains) {
                 return (route.path.indexOf(e.pathContains) !== -1);
             } else if(e.path){
                 return (e.path === route.path);
+            }else if(e.method){
+                if(e.method === route.method) {
+                    return true;
+                }
             }
         };
     };

--- a/test/tests.js
+++ b/test/tests.js
@@ -364,6 +364,30 @@ describe('Patronus', function() {
         });
     });
 
+    describe('should run tests from all routes except those containing:', function() {
+
+        it('POST /bad/', function(done) {
+            var tests = Patronus.allTests(server, {
+                ignore: [{
+                    method: 'POST',
+                    pathContains: '/bad/'
+                }]
+            });
+
+            // assert that in the tests, no route has the method + partial payload above
+            tests.forEach(function (test) {
+                assert.notDeepEqual({
+                    path: test.path,
+                    method: test.method
+                }, {
+                    method: 'POST',
+                    path: '/payload/bad/'
+                });
+            });
+            done();
+        });
+    });
+
     describe('should run tests from all routes excluding method:', function() {
 
         it('POST', function(done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -364,6 +364,37 @@ describe('Patronus', function() {
         });
     });
 
+    describe('should run tests from all routes excluding method:', function() {
+
+        it('POST', function(done) {
+            var tests = Patronus.allTests(server, {
+                ignore: [{
+                    method: 'POST'
+                }]
+            });
+
+            // assert that in the tests, no route has the method + payload above
+            tests.forEach(function (test) {
+                assert.notEqual(test.method, 'POST');
+            });
+            done();
+        });
+
+        it('GET', function(done) {
+            var tests = Patronus.allTests(server, {
+                ignore: [{
+                    method: 'GET'
+                }]
+            });
+
+            // assert that in the tests, no route has the method + payload above
+            tests.forEach(function (test) {
+                assert.notEqual(test.method, 'GET');
+            });
+            done();
+        });
+    });
+
     describe('should run tests from just select routes', function() {
         server.connection({ port: 9998, labels: 'web' });
         var webServer = server.select('web');

--- a/test/tests.js
+++ b/test/tests.js
@@ -373,7 +373,7 @@ describe('Patronus', function() {
                 }]
             });
 
-            // assert that in the tests, no route has the method + payload above
+            // assert that in the tests, no route has the method above
             tests.forEach(function (test) {
                 assert.notEqual(test.method, 'POST');
             });
@@ -387,7 +387,7 @@ describe('Patronus', function() {
                 }]
             });
 
-            // assert that in the tests, no route has the method + payload above
+            // assert that in the tests, no route has the method above
             tests.forEach(function (test) {
                 assert.notEqual(test.method, 'GET');
             });


### PR DESCRIPTION
This allows for allTests filters that ignore an entire method class:
```
var opts = {
  ignore: [ {
      method: 'post'
    }]};
Patronus.allTests(server, opts);
```

I've included a regression test for this specific case and a test for pathContains for full statement coverage. It seems there are several branches that aren't covered, but they don't seem to be related to my changes.

Please let me know if there are any issues with this request.